### PR TITLE
Fix missing end statement in functions>solveTrajectDist.m

### DIFF
--- a/functions/solveTrajectDist.m
+++ b/functions/solveTrajectDist.m
@@ -94,6 +94,7 @@ if ~success
     icMat = ichol_autocomp(A);
     catch
     error('Unable to solve: Calculation of icMat using ichol_autocomp failed, and no solution could be determined with an empty preconditioner.');
+    end
 end
 
 % Reset tolerance to initial value or to a specific value if needed


### PR DESCRIPTION
The examples geo1 and geo2 (and maybe more) weren't working, because the function solveTrajectDist didn't execute correctly, since this end statement was missing.